### PR TITLE
On Amazon Linux python_runtime '3' installs python26

### DIFF
--- a/lib/poise_python/python_providers/system.rb
+++ b/lib/poise_python/python_providers/system.rb
@@ -40,7 +40,7 @@ module PoisePython
         rhel: {default: %w{python}},
         centos: {default: %w{python}},
         fedora: {default: %w{python3 python}},
-        amazon: {default: %w{python27 python26 python}},
+        amazon: {default: %w{python34 python27 python26 python}},
       })
 
       # Output value for the Python binary we are installing. Seems to match


### PR DESCRIPTION
On amazon, the command:

```ruby
python_runtime '3' 
```

Creates the error:

> poise_languages_system[python] (/var/chef/api-chef/local-mode-cache/cache/cookbooks/poise-languages/files/halite_gem/poise_languages/system/mixin.rb line 32) had an error: PoiseLanguages::Error: Package python26 would install 2.6.9-2.84.amzn1, which does not match 3. Please set the package_name or package_version provider options


work around:

```ruby
python_runtime '3' do 
   options package_name: 'python34'
end
```