### PR TITLE
Fix epel-7 and epel-6 broken links for python2.7

### DIFF
--- a/lib/poise_python/python_providers/scl.rb
+++ b/lib/poise_python/python_providers/scl.rb
@@ -44,8 +44,8 @@ module PoisePython
       })
       scl_package('2.7.8', 'python27', 'python27-python-devel', {
         ['redhat', 'centos'] => {
-          '~> 7.0' => 'https://www.softwarecollections.org/en/scls/rhscl/python27/epel-7-x86_64/download/rhscl-python27-epel-7-x86_64.noarch.rpm',
-          '~> 6.0' => 'https://www.softwarecollections.org/en/scls/rhscl/python27/epel-6-x86_64/download/rhscl-python27-epel-6-x86_64.noarch.rpm',
+          '~> 7.0' => 'https://www.softwarecollections.org/repos/rhscl/python27/epel-7-x86_64/noarch/rhscl-python27-epel-7-x86_64-1-2.noarch.rpm',
+          '~> 6.0' => 'https://www.softwarecollections.org/repos/rhscl/python27/epel-6-x86_64/noarch/rhscl-python27-epel-6-x86_64-1-2.noarch.rpm',
         },
         'fedora' => {
           '~> 21.0' => 'https://www.softwarecollections.org/en/scls/rhscl/python27/fedora-21-x86_64/download/rhscl-python27-fedora-21-x86_64.noarch.rpm',


### PR DESCRIPTION
Current python2.7 links from epel-6 and epel-7 systems (from Software Collections) are broken. I found what I think are the correct links.

> Fedora-20 links are also broken, but I think that they have been removed forever.