### PR TITLE
Update to support SCL Python 3.6 (rh-python36)

### DIFF
--- a/lib/poise_python/python_providers/scl.rb
+++ b/lib/poise_python/python_providers/scl.rb
@@ -26,7 +26,8 @@ module PoisePython
     class Scl < Base
       include PoiseLanguages::Scl::Mixin
       provides(:scl)
-      scl_package('3.5.1', 'rh-python35', 'rh-python35-python-devel', '>= 7.0')
+      scl_package('3.6.3', 'rh-python36', 'rh-python36-python-devel')
+      scl_package('3.5.1', 'rh-python35', 'rh-python35-python-devel')
       scl_package('3.4.2', 'rh-python34', 'rh-python34-python-devel')
       scl_package('3.3.2', 'python33', 'python33-python-devel')
       scl_package('2.7.8', 'python27', 'python27-python-devel')

--- a/test/spec/python_providers/scl_spec.rb
+++ b/test/spec/python_providers/scl_spec.rb
@@ -41,7 +41,7 @@ describe PoisePython::PythonProviders::Scl do
 
   context 'with version ""' do
     let(:python_version) { '' }
-    it_behaves_like 'scl provider', 'rh-python35'
+    it_behaves_like 'scl provider', 'rh-python36'
   end # /context with version ""
 
   context 'with version "2"' do
@@ -51,7 +51,17 @@ describe PoisePython::PythonProviders::Scl do
 
   context 'with version "3"' do
     let(:python_version) { '3' }
+    it_behaves_like 'scl provider', 'rh-python36'
+  end # /context with version "3"
+
+  context 'with version "3.5"' do
+    let(:python_version) { '3.5' }
     it_behaves_like 'scl provider', 'rh-python35'
+  end # /context with version "3"
+
+  context 'with version "3.4"' do
+    let(:python_version) { '3.4' }
+    it_behaves_like 'scl provider', 'rh-python34'
   end # /context with version "3"
 
   context 'with version "3.3"' do
@@ -62,7 +72,7 @@ describe PoisePython::PythonProviders::Scl do
   context 'with version "" on CentOS 6' do
     let(:chefspec_options) { {platform: 'centos', version: '6.9'} }
     let(:python_version) { '' }
-    it_behaves_like 'scl provider', 'rh-python34'
+    it_behaves_like 'scl provider', 'rh-python36'
   end # /context with version "" on CentOS 6
 
   context 'action :uninstall' do


### PR DESCRIPTION
- Add 'rh-python36' as default for version "" and "3"
- Allow 'rh-python35' for RHEL 6 (remove special case)
- Update tests accordingly
- Fixes #125