### PR TITLE
Make the pip hack script compatible with pip 18.1

### DIFF
--- a/lib/poise_python/resources/python_package.rb
+++ b/lib/poise_python/resources/python_package.rb
@@ -50,7 +50,11 @@ except ImportError:
   # Pip 10 moved all internals to their own package.
   from pip._internal.commands import InstallCommand
   from pip._internal.index import PackageFinder
-  from pip._internal.req import InstallRequirement
+  try:
+    # Pip 18.1 moved from_line to the constructors
+    from pip._internal.req.constructors import install_req_from_line
+  except ImportError:
+    from pip._internal.req import InstallRequirement
 
 packages = {}
 cmd = InstallCommand()
@@ -73,7 +77,10 @@ with cmd._build_session(options) as session:
   finder = PackageFinder(**finder_options)
   find_all = getattr(finder, 'find_all_candidates', getattr(finder, '_find_all_versions', None))
   for arg in args:
-    req = InstallRequirement.from_line(arg)
+    try:
+      req = install_req_from_line(arg)
+    except NameError:
+      req = InstallRequirement.from_line(arg)
     found = finder.find_requirement(req, True)
     all_candidates = find_all(req.name)
     candidate = [c for c in all_candidates if c.location == found]


### PR DESCRIPTION
It [moved](https://github.com/pypa/pip/commit/a5a07fe61c4861c58fded7420c929d56cde11a89) the from_line method in a backwards-incompatible way. This should resolve the remainder of #133.

My Python is pretty atrophied, but I tested this against the following recipe and it converged successfully.

```ruby
apt_update 'default'

python_runtime '2'

python_virtualenv '/tmp/piplatest' do
  python '2'
end

python_virtualenv '/tmp/pip18' do
  python '2'
  pip_version '18.0'
end

python_virtualenv '/tmp/pip10' do
  python '2'
  pip_version '10.0.1'
end

python_virtualenv '/tmp/pip9' do
  python '2'
  pip_version '9.0.3'
end
```